### PR TITLE
Update class-dcms-simple-author-bio.php

### DIFF
--- a/includes/class-dcms-simple-author-bio.php
+++ b/includes/class-dcms-simple-author-bio.php
@@ -103,6 +103,8 @@ class Dcms_Simple_Author_Bio{
 			return $content.$this->get_author_bio( $show_social, $show_all_posts );
 
 		}
+		
+		return $content // If we are a page, we need content back.
 
 	}
 


### PR DESCRIPTION
You should always return $content outside of conditions. I was using your plugin, and none of my pages were displaying content. The page object does not return true for is_single, so $content was never returned, and then therefore not output to screen. this fixes the problem.